### PR TITLE
Features/cu 86dru2cc3 get exchanges list all supported markets id and name no pagination required

### DIFF
--- a/src/main/java/ar/com/api/exchanges/services/ExchangeApiService.java
+++ b/src/main/java/ar/com/api/exchanges/services/ExchangeApiService.java
@@ -45,9 +45,10 @@ public class ExchangeApiService {
     public Flux<ExchangeBase> getAllSupportedMarkets() {
 
         log.info("In service getAllSupportedMarkets {} ",
-                externalServerConfig.getExchangeById() + externalServerConfig.getExchangeListMarket());
+                externalServerConfig.getExchangeList() + externalServerConfig.getExchangeListMarket());
 
-        return null;
+        return httpServiceCall.getFluxObject(externalServerConfig.getExchangeList()
+                + externalServerConfig.getExchangeListMarket(), ExchangeBase.class);
     }
 
     /**

--- a/src/test/java/ar/com/api/exchanges/services/ExchangeApiServiceTest.groovy
+++ b/src/test/java/ar/com/api/exchanges/services/ExchangeApiServiceTest.groovy
@@ -6,6 +6,7 @@ import ar.com.api.exchanges.dto.ExchangeDTO
 import ar.com.api.exchanges.enums.ErrorTypeEnum
 import ar.com.api.exchanges.exception.ApiServeErrorrException
 import ar.com.api.exchanges.model.Exchange
+import ar.com.api.exchanges.model.ExchangeBase
 import org.instancio.Instancio
 import org.springframework.http.HttpStatus
 import reactor.core.publisher.Flux
@@ -23,6 +24,7 @@ class ExchangeApiServiceTest extends Specification {
         externalServerConfigMock = Mock(ExternalServerConfig)
 
         externalServerConfigMock.getExchangeList() >> "exchangeListEndPointMock"
+        externalServerConfigMock.getExchangeListMarket() >> "exchangeListMarketEndPointMock"
 
         exchangeApiService = new ExchangeApiService(httpServiceCallMock, externalServerConfigMock)
     }
@@ -89,5 +91,69 @@ class ExchangeApiServiceTest extends Specification {
                             errorActual.getMessage() == clientErrorExpected.getMessage()
                 }
                 .verify()
+    }
+
+    def "GetAllSupportedMarkets should successfully retrieve a list of markets Supported"() {
+        given: "Mocked external server config and filter DTO"
+        def expectedMarketExchangeList = Instancio.ofList(ExchangeBase.class)
+                .size(7).create()
+        httpServiceCallMock.getFluxObject(externalServerConfigMock.getExchangeList()
+                + externalServerConfigMock.getExchangeListMarket(), ExchangeBase.class) >>
+                Flux.fromIterable(expectedMarketExchangeList)
+
+        when: "getAllSupportedMarkets is called without filter"
+        def returnedObject = exchangeApiService.getAllSupportedMarkets()
+
+        then: "The correct number of Markets is returned,and content is verified"
+        StepVerifier.create(returnedObject)
+                .recordWith(ArrayList::new)
+                .expectNextCount(expectedMarketExchangeList.size())
+                .consumeRecordedWith { actualExchanges ->
+                    assert actualExchanges.containsAll(expectedMarketExchangeList)
+                }
+                .verifyComplete()
+    }
+
+    def "GetAllSupportedMarkets should handle 4xx client error gracefully"() {
+        given: "A mock setup for ExternalServerConfig and HttServiceCall with a 4xx client error"
+        def clientErrorExpected = new ApiServeErrorrException("An error occurred on APIClient", "Forbidden",
+                ErrorTypeEnum.GECKO_CLIENT_ERROR, HttpStatus.FORBIDDEN)
+        httpServiceCallMock.getFluxObject(externalServerConfigMock.getExchangeList()
+                + externalServerConfigMock.getExchangeListMarket(), ExchangeBase.class)
+                >> Flux.error(clientErrorExpected)
+
+        when: "GetAllSupportedMarkets is invoked with a 4xx error scenario"
+        def actualExceptionObject = exchangeApiService.getAllSupportedMarkets()
+
+        then: "The service return 4xx client"
+        StepVerifier.create(actualExceptionObject)
+                .expectErrorMatches {errorActual ->
+                    errorActual instanceof ApiServeErrorrException &&
+                            errorActual.getErrorTypeEnum() == ErrorTypeEnum.GECKO_CLIENT_ERROR &&
+                            errorActual.getHttpStatus().is4xxClientError() &&
+                            errorActual.getMessage() == clientErrorExpected.getMessage()
+                }.verify()
+    }
+
+    def "GetAllSupportedMarkets should handle 5xx Server error gracefully"() {
+        given: "A mock setup for ExternalServerConfig and HttServiceCall with a 5xx server error"
+        def clientErrorExpected = new ApiServeErrorrException("An error occurred on APIServer",
+                "Internal Server Error",
+                ErrorTypeEnum.GECKO_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR)
+        httpServiceCallMock.getFluxObject(externalServerConfigMock.getExchangeList()
+                + externalServerConfigMock.getExchangeListMarket(), ExchangeBase.class)
+                >> Flux.error(clientErrorExpected)
+
+        when: "GetAllSupportedMarkets is invoked with a 5xx error scenario"
+        def actualExceptionObject = exchangeApiService.getAllSupportedMarkets()
+
+        then: "The service return 4xx client"
+        StepVerifier.create(actualExceptionObject)
+                .expectErrorMatches {errorActual ->
+                    errorActual instanceof ApiServeErrorrException &&
+                            errorActual.getErrorTypeEnum() == ErrorTypeEnum.GECKO_SERVER_ERROR &&
+                            errorActual.getHttpStatus().is5xxServerError() &&
+                            errorActual.getMessage() == clientErrorExpected.getMessage()
+                }.verify()
     }
 }


### PR DESCRIPTION
Changes for fetch All Exchanges supported by CoinGeko API of the service, change router, handler and service. And add test
