### PR TITLE
Features/cu 86dru2cj6 get exchangesidvolume chart get 24 hour rolling trading volume data in btc for a given exchange

### DIFF
--- a/src/main/java/ar/com/api/exchanges/dto/VolumeChartByIdDTO.java
+++ b/src/main/java/ar/com/api/exchanges/dto/VolumeChartByIdDTO.java
@@ -1,5 +1,7 @@
 package ar.com.api.exchanges.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,8 +9,12 @@ import lombok.Getter;
 @Builder
 public class VolumeChartByIdDTO implements IFilterDTO {
 
+    @NotBlank(message = "Exchange ID cannot be blanc.")
+    @NotEmpty(message = "Exchange ID cannot be empty.")
     private String id;
-    private int days;
+    @NotBlank(message = "Days cannot be blanc.")
+    @NotEmpty(message = "Days cannot be empty.")
+    private String days;
 
     @Override
     public String getUrlFilterString() {

--- a/src/main/java/ar/com/api/exchanges/handler/utilities/MapperHandler.java
+++ b/src/main/java/ar/com/api/exchanges/handler/utilities/MapperHandler.java
@@ -3,6 +3,7 @@ package ar.com.api.exchanges.handler.utilities;
 import ar.com.api.exchanges.dto.ExchangeDTO;
 import ar.com.api.exchanges.dto.ExchangeVolumeDTO;
 import ar.com.api.exchanges.dto.TickersByIdDTO;
+import ar.com.api.exchanges.dto.VolumeChartByIdDTO;
 import ar.com.api.exchanges.utils.StringToInteger;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import reactor.core.publisher.Mono;
@@ -39,6 +40,15 @@ public class MapperHandler {
                 .page(page)
                 .depth(sRequest.queryParam("depth"))
                 .order(sRequest.queryParam("order"))
+                .build());
+    }
+
+    public static Mono<VolumeChartByIdDTO> createVolumeChartByIdDTOFromRequest(ServerRequest sRequest) {
+
+        return Mono.just(VolumeChartByIdDTO
+                .builder()
+                .id(sRequest.pathVariable("idMarket"))
+                .days(sRequest.queryParam("days").get())
                 .build());
     }
 }

--- a/src/main/java/ar/com/api/exchanges/services/ExchangeApiService.java
+++ b/src/main/java/ar/com/api/exchanges/services/ExchangeApiService.java
@@ -81,12 +81,14 @@ public class ExchangeApiService {
 
     public Flux<String> getVolumeChartById(VolumeChartByIdDTO filterDto) {
 
-        log.info("In service getTicketExchangeById {}"
-                ,externalServerConfig.getExchangeList() + externalServerConfig.getExchangeVolumeChart());
+        log.info("In service getTicketExchangeById {}",
+                externalServerConfig.getExchangeList() + externalServerConfig.getExchangeVolumeChart());
 
         String urlApiGecko = String.format(externalServerConfig.getExchangeVolumeChart(), filterDto.getId());
 
-        return null;
+        return httpServiceCall.getFluxObject(externalServerConfig.getExchangeList() + urlApiGecko
+                        + filterDto.getUrlFilterString(),
+                String.class);
     }
 
 }


### PR DESCRIPTION
PR for Changes for fetch List of volume data whit Exchange ID and days by CoinGeko API of the service, change router, handler and service. And add test


